### PR TITLE
This fixes: deployment fails due to missing required graylog.root_email property

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ bosh upload release
 ```
 
 ### Deploying to *bosh-lite*.
-a sample cloud-config and deployment manifest is provided in the `templates` directory.
+A sample cloud-config and deployment manifest is provided in the `templates` directory.  
+There is a bunch of settings available to be tuned in the deployment manifest. In each of the jobs there is a spec file that contains a properties key. Any of these can be add to the `properties:` at the bottom of your deployment manifest.
 
 ```
+cp templates/bosh-lite-deployment.yml bosh-lite-deployment.yml
 bosh update cloud-config templates/bosh-lite-cloud-config.yml
-bosh deployment templates/bosh-lite-deployment.yml
+bosh deployment bosh-lite-deployment.yml
 bosh deploy
 ```
 

--- a/templates/bosh-lite-deployment.yml
+++ b/templates/bosh-lite-deployment.yml
@@ -1,6 +1,6 @@
 ---
 name: graylog
-director_uuid: 93c01d2d-a2a5-49d8-8d02-389fd223a9cf
+director_uuid: #FIX ME
 
 releases:
 - name: graylog
@@ -66,6 +66,12 @@ instance_groups:
   jobs:
   - name: graylog
     release: graylog
+update:
+  canaries: 1
+  max_in_flight: 1
+  canary_watch_time: 1000-600000
+  update_watch_time: 1000-600000
+
 properties:
   elasticsearch:
     cluster_name: graylog
@@ -78,9 +84,5 @@ properties:
   graylog:
     elasticsearch_discovery_zen_ping_unicast_hosts: 10.244.0.21:9300
     mongodb_uri: mongodb://10.244.0.20/graylog
+    root_email: # FIX ME
 
-update:
-  canaries: 1
-  max_in_flight: 1
-  canary_watch_time: 1000-600000
-  update_watch_time: 1000-600000


### PR DESCRIPTION
* Add note about the properties that are availble to be tuned in a deployment manifest.
* add missing required property `graylog.root_email` to deployment manifest template