### PR TITLE
Add slack plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 BOSH release for graylog (<https://www.graylog.org/>) - tool for centrally collecting logging events for your infrastructure and applications.
 
+This release includes the [Slack plugin](https://marketplace.graylog.org/addons/2b7c3403-60d8-488e-b4be-79364bde1634).
+
 ## Usage
 
 ### Setting up local environment

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,6 +10,9 @@ graylog/graylog-2.2.3.tgz:
   size: 99971278
   object_id: 7a04199d-05d3-464d-5023-211c0cbd041d
   sha: 0d3bdd24104c87f4e3739959c0c3d009cf090242
+graylog/graylog-plugin-slack-2.4.0.jar:
+  size: 26462
+  sha: 10529654afe3b8a93a991ca487dbfdbd01a37e81
 mongodb/mongodb-linux-x86_64-3.4.2.tgz:
   size: 86473759
   object_id: a68edeb2-27a4-4532-96e1-09b00145f9c7

--- a/packages/graylog/packaging
+++ b/packages/graylog/packaging
@@ -7,3 +7,6 @@ set -u # report the usage of uninitialized variables
 
 tar xzf graylog/graylog-2.2.3.tgz
 cp -R graylog-2.2.3/* $BOSH_INSTALL_TARGET
+
+# Install slack plugin
+cp graylog/*.jar $BOSH_INSTALL_TARGET/plugin/

--- a/packages/graylog/spec
+++ b/packages/graylog/spec
@@ -5,3 +5,4 @@ dependencies: []
 
 files:
   - graylog/graylog-2.2.3.tgz
+  - graylog/graylog-plugin-slack-2.4.0.jar # from https://github.com/graylog-labs/graylog-plugin-slack/releases/download/2.4.0/graylog-plugin-slack-2.4.0.jar


### PR DESCRIPTION
Add [slack plugin](https://marketplace.graylog.org/addons/2b7c3403-60d8-488e-b4be-79364bde1634). It just [has to be copied](http://docs.graylog.org/en/2.3/pages/plugins.html#installing-and-loading-plugins) to `plugin`. The slack plugin then shows up in graylog when I've tested this release locally.