### PR TITLE
Add geoipdate job

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -4,6 +4,7 @@ elasticsearch/elasticsearch-2.4.4.tar.gz:
   sha: cdb5068d1baa07388e522c3bc04cca38aa8f3048
 geoipupdate/geoipupdate-2.5.0.tar.gz:
   size: 371882
+  object_id: a00f4ce6-ea45-4301-7569-c92b4042ec93
   sha: 79c5c9ba0f7a89d921b640f140ce0f5dc95bc8eb
 graylog/graylog-2.2.2.tgz:
   size: 99956086

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -2,6 +2,9 @@ elasticsearch/elasticsearch-2.4.4.tar.gz:
   size: 27343272
   object_id: 06f85038-ba22-46f7-a7c7-058d0d6aa7c2
   sha: cdb5068d1baa07388e522c3bc04cca38aa8f3048
+geoipupdate/geoipupdate-2.5.0.tar.gz:
+  size: 371882
+  sha: 79c5c9ba0f7a89d921b640f140ce0f5dc95bc8eb
 graylog/graylog-2.2.2.tgz:
   size: 99956086
   object_id: dee996d9-8ed8-453e-85cb-27ea5362ff0c

--- a/jobs/geoipupdate/spec
+++ b/jobs/geoipupdate/spec
@@ -1,0 +1,13 @@
+---
+name: geoipupdate
+
+templates:
+  bin/geoipupdate.sh: bin/geoipupdate.sh
+  bin/geoipupdate-cron: bin/geoipupdate-cron
+  bin/pre-start: bin/pre-start
+  etc/GeoIP.conf: etc/GeoIP.conf
+
+packages:
+  - geoipupdate
+
+properties: {}

--- a/jobs/geoipupdate/templates/bin/geoipupdate-cron
+++ b/jobs/geoipupdate/templates/bin/geoipupdate-cron
@@ -1,0 +1,1 @@
+0 9 * * Wed root /var/vcap/jobs/geoipupdate/bin/geoipupdate.sh

--- a/jobs/geoipupdate/templates/bin/geoipupdate.sh
+++ b/jobs/geoipupdate/templates/bin/geoipupdate.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -eux
+
+JOB_NAME=geoipupdate
+JOB_DIR=/var/vcap/jobs/$JOB_NAME
+LOG_DIR=/var/vcap/sys/log/$JOB_NAME
+STORE_DIR=/var/vcap/store/$JOB_NAME
+
+mkdir -p $LOG_DIR
+chown vcap:vcap $LOG_DIR
+
+{
+  echo "$(date) running geoipupdate"
+
+  # graylog looks for the geoip database at
+  # /etc/graylog/server/GeoLite2-City.mmdb, so we download the db
+  # to the bosh standard location and add a symlink for graylog
+
+  mkdir -p $STORE_DIR
+  mkdir -p /etc/graylog
+  ln -sf $STORE_DIR /etc/graylog/server | true
+
+  chown vcap -R $STORE_DIR
+
+  chpst -u vcap:vcap /var/vcap/packages/geoipupdate/bin/geoipupdate \
+    -v \
+    -f $JOB_DIR/etc/GeoIP.conf \
+    -d $STORE_DIR
+
+  exit 0
+} >>$LOG_DIR/$JOB_NAME.stdout.log \
+  2>>$LOG_DIR/$JOB_NAME.stderr.log

--- a/jobs/geoipupdate/templates/bin/geoipupdate.sh
+++ b/jobs/geoipupdate/templates/bin/geoipupdate.sh
@@ -27,7 +27,5 @@ chown vcap:vcap $LOG_DIR
     -v \
     -f $JOB_DIR/etc/GeoIP.conf \
     -d $STORE_DIR
-
-  exit 0
 } >>$LOG_DIR/$JOB_NAME.stdout.log \
   2>>$LOG_DIR/$JOB_NAME.stderr.log

--- a/jobs/geoipupdate/templates/bin/pre-start
+++ b/jobs/geoipupdate/templates/bin/pre-start
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# run it immediately
+/var/vcap/jobs/geoipupdate/bin/geoipupdate.sh
+
+# schedule the job with cron
+cp /var/vcap/jobs/geoipupdate/bin/geoipupdate-cron /etc/cron.d

--- a/jobs/geoipupdate/templates/etc/GeoIP.conf
+++ b/jobs/geoipupdate/templates/etc/GeoIP.conf
@@ -1,0 +1,13 @@
+# suggested config for GeoLite2 databases
+# from https://dev.maxmind.com/geoip/geoipupdate/
+
+# The following AccountID and LicenseKey are required placeholders.
+# For geoipupdate versions earlier than 2.5.0, use UserId here instead of AccountID.
+AccountID 0
+LicenseKey 000000000000
+
+# Include one or more of the following edition IDs:
+# * GeoLite2-City - GeoLite 2 City
+# * GeoLite2-Country - GeoLite2 Country
+# For geoipupdate versions earlier than 2.5.0, use ProductIds here instead of EditionIDs.
+EditionIDs GeoLite2-City GeoLite2-Country

--- a/manifests/graylog.yml
+++ b/manifests/graylog.yml
@@ -87,6 +87,9 @@ instance_groups:
         root_username: admin
         # default root_password = admin ; below is sha2 hash of it.
         root_password_sha2: 8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
+  - name: geoipupdate
+    release: graylog
+    properties: {}
 
 variables:
 - name: password-secret

--- a/packages/geoipupdate/packaging
+++ b/packages/geoipupdate/packaging
@@ -1,0 +1,19 @@
+#
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+# Available variables
+# $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
+# $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
+
+VERSION=2.5.0
+
+tar xzfv geoipupdate/geoipupdate-${VERSION}.tar.gz
+
+cd geoipupdate-${VERSION}
+
+./configure --prefix $BOSH_INSTALL_TARGET
+
+make
+
+make install

--- a/packages/geoipupdate/spec
+++ b/packages/geoipupdate/spec
@@ -1,0 +1,7 @@
+---
+name: geoipupdate
+
+dependencies: []
+
+files:
+  - geoipupdate/geoipupdate-2.5.0.tar.gz # from https://github.com/maxmind/geoipupdate/releases/download/v2.5.0/geoipupdate-2.5.0.tar.gz


### PR DESCRIPTION
As requested in #10, this will add the [geoipupdate tool](https://dev.maxmind.com/geoip/geoipupdate/) which will download the free GeoLite2 Databases from Maxmind. It will run once when the job starts, and then weekly using cron.

By default graylog will look for the database location at `/etc/graylog/server/GeoLite2-City.mmdb`, and a symlink is created so this path will work. This means the graylog [instructions to enable geolocation](http://docs.graylog.org/en/2.3/pages/geolocation.html) will work without modification.
